### PR TITLE
synced dispatch support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export interface Store<T, M> {
 	set<K extends keyof M>(state: T, event: K | '*'): void;
 
 	on<K extends keyof M>(event: K, handler: Handler<T, M[K]>): Unsubscriber;
-	dispatch<K extends keyof M>(event: K, data: M[K]): Promise<void>;
+	dispatch<K extends keyof M>(event: K, data: M[K]): Promise<void> | void;
 
 	listen(func: Listener<T>): Unsubscriber;
 	listen<K extends keyof M>(event: K | '*', func: Listener<T>): Unsubscriber;

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export default function (obj) {
 
 		dispatch(evt, data) {
 			var tmp = loop(tree[evt] || [], data, klona(value), 0);
-			if (typeof tmp.then == 'function') return tmp.then(x => $.set(x, evt));
+			if (tmp && typeof tmp.then == 'function') return tmp.then(x => x != undefined && $.set(x, evt));
 			else $.set(tmp, evt);
 		}
 	};

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,10 @@ export default function (obj) {
 
 		dispatch(evt, data) {
 			var tmp = loop(tree[evt] || [], data, klona(value), 0);
-			if (typeof tmp.then == 'function') return tmp.then(x => x != undefined && $.set(x, evt));
+			if (typeof tmp.then == 'function') return tmp.then(x => {
+				if (x == null) throw 'state did not returned!';
+				$.set(x, evt);
+			});
 			else $.set(tmp, evt);
 		}
 	};

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export default function (obj) {
 
 		dispatch(evt, data) {
 			var tmp = loop(tree[evt] || [], data, klona(value), 0);
-			if (tmp && typeof tmp.then == 'function') return tmp.then(x => x != undefined && $.set(x, evt));
+			if (typeof tmp.then == 'function') return tmp.then(x => x != undefined && $.set(x, evt));
 			else $.set(tmp, evt);
 		}
 	};

--- a/test/index.js
+++ b/test/index.js
@@ -76,8 +76,25 @@ test('$.listen', t => {
 	ctx.set({ x: 123 }, 'hello'); // +1 (bat)
 });
 
-test('$.dispatch', async t => {
+test('$.dispatch sync', t => {
 	let ctx = lib({ foo: 123 });
+
+	t.is(typeof ctx.dispatch, 'function', '~> function');
+
+	let data = { bar: 456 };
+
+	let foo = ctx.dispatch('hello', data);
+	t.true(foo instanceof Promise === false, '~> not returns a Promise');
+
+	t.is(foo, undefined, '~> returns to void');
+
+	t.same(ctx.state, { foo: 123 }, '~> $.state NOT changed (no reducers)');
+
+	t.end();
+});
+
+test('$.dispatch async', async t => {
+	let ctx = lib((async () => ({ foo: 123 }))());
 
 	t.is(typeof ctx.dispatch, 'function', '~> function');
 


### PR DESCRIPTION
Sometimes it may be necessary to use it similar to the following.

```js
store.dispatch('openDialog');
store.dispatch('switchToEditMode', data);
```
In current time async/await can be use. 
```js
await store.dispatch('openDialog');
await store.dispatch('switchToEditMode', data);
```
But easier to use synced mode. This PR enables sync/async usage both of them.